### PR TITLE
no-action-bound-decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ Then configure the rules you want to use under the rules section.
 * [`import-screaming-snake-case`](docs/rules/import-screaming-snake-case.md): allows you to specify globs in your config,
   if an import file should be using screaming snakecase (used for
 importing constant files).
+* [`no-action-bound-decorator`](docs/rules/no-action-bound-decorator.md): prevent usage of `@action.bound` supplied by MobX library.

--- a/docs/rules/no-action-bound-decorator.md
+++ b/docs/rules/no-action-bound-decorator.md
@@ -1,0 +1,35 @@
+# Prefer arrow function over action.bound decorator
+(no-action-bound-decorator)
+
+We prefer using arrow function to bind `this` instead of MobX&#39;s @action.bound decorator (no-action-bound-decorator)
+
+## Rule Details
+
+When using MobX to create a store, we can automatically bind `this` (the
+context) by using the decorator `@action.bound`. However, we are also
+able to bind `this` by using the arrow function. Since the arrow
+function is an ECMAScript functionality, we prefer it over something
+provided by MobX.
+
+Examples of **incorrect** code for this rule:
+
+```js
+class Test {
+  @action.bound
+  test () {
+    // do stuff
+  }
+}
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+class Test {
+  @action
+  test = () => {
+    // do stuff
+  }
+}
+```

--- a/lib/rules/no-action-bound-decorator.js
+++ b/lib/rules/no-action-bound-decorator.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview We prefer using arrow function to bind `this` instead of MobX's @action.bound decorator
+ * @author Seiji Naganuma
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "We prefer using arrow function to bind `this` instead of MobX's @action.bound decorator",
+            category: "Best Practice",
+            recommended: false
+        },
+        fixable: null,
+        schema: []
+    },
+
+    create: function(context) {
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        // any helper functions should go here or else delete this section
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+          MethodDefinition: function(node) {
+            // bail if no decorators
+            if (!node.decorators) { return; }
+
+            // iterate through decorators
+            node.decorators.forEach(function (decorator) {
+              // bail if no expression
+              if (!decorator.expression) { return; }
+              // bail if expression has no object or property
+              if (!decorator.expression.object || !decorator.expression.property) { return;}
+
+              if (decorator.expression.object.name === 'action'
+                  && decorator.expression.property.name === 'bound') {
+                context.report(node, "Prefer arrow function to bind `this` over @action.bound");
+              }
+            });
+          }
+        };
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-curology",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Custom ESlint rules for Curology",
   "author": "Curology <engineering@curology.com>",
   "keywords": [

--- a/tests/lib/rules/no-action-bound-decorator.js
+++ b/tests/lib/rules/no-action-bound-decorator.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview We prefer using arrow function to bind `this` instead of MobX&#39;s @action.bound decorator
+ * @author Seiji Naganuma
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-action-bound-decorator"),
+  RuleTester = require("eslint").RuleTester;
+
+  RuleTester.setDefaultConfig({
+    parser: "babel-eslint",
+    parserOptions: {
+      ecmaVersion: 6,
+      sourceType: "module"
+    }
+  });
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ERRORS = [{
+  message: "Prefer arrow function to bind `this` over @action.bound",
+  type: "MethodDefinition"
+}];
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-action-bound-decorator", rule, {
+
+    valid: [
+      "class Test { @action test() {} }",
+      "class Test { test () {} }",
+      "class Test { @action test = () => {} }",
+      "class Test { test = () => {} }"
+    ],
+
+    invalid: [
+        {
+            code: "class Test { @action.bound test () {} }",
+            errors: ERRORS
+        }
+    ]
+});


### PR DESCRIPTION
As a team, we decided to not use the MobX supplied `@action.bound` decorator as a way to bind the context to the function (`this`). This rule will be flagged if that decorator is used:

Invalid:
```js
class Test {
  @action.bound
  test () {
  }
}
```

Valid:
```js
class Test {
  @action
  test = () => {
  }
}
```